### PR TITLE
Add .travis.yml for testing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: common-lisp
+sudo: required
+
+env:
+  matrix:
+    - LISP=sbcl
+    - LISP=ccl
+    - LISP=clisp
+
+install:
+  # Install cl-travis
+  - curl https://raw.githubusercontent.com/luismbo/cl-travis/master/install.sh | bash
+
+script:
+  - cl -e '(setf *debugger-hook*
+                 (lambda (c h)
+                   (declare (ignore c h))
+                   (uiop:quit -1)))'
+       -e '(asdf:compile-system :basic-binary-ipc :force t)'
+       -e '(ql:quickload :basic-binary-ipc-tests)'
+       -e '(lisp-unit:run-tests :all :basic-binary-ipc.tests)'


### PR DESCRIPTION
This PR adds a `.travis.yml` so you can test the library on the cloud with [Travis](travis-ci.org).