### PR TITLE
[Tests] Fix "resolve-ipv4-address" flakiness

### DIFF
--- a/tests/ipv4.lisp
+++ b/tests/ipv4.lisp
@@ -13,6 +13,11 @@
     (push port *used-server-ports*)
     port))
 
+(defun example-com-valid-address (resolved-addr)
+  (cond ((string= resolved-addr "93.184.216.119") t)
+	((string= resolved-addr "93.184.216.34") t)
+	(t nil)))
+
 (define-test make-ipv4-tcp-server
   (:tag :ipv4-tcp-socket)
   (let* ((port   (random-server-port))
@@ -203,5 +208,5 @@
 
 (define-test resolve-ipv4-address
   (:tag :resolve-ipv4-address)
-  (assert-equal "93.184.216.119" (resolve-ipv4-address "example.com"))
+  (assert-true  (example-com-valid-address (resolve-ipv4-address "example.com")))
   (assert-false (resolve-ipv4-address "example12341.com")))


### PR DESCRIPTION
It appears that example.com now has at least 2 (that I could determine) IP addresses that it could possibly resolve to. I am not sure exactly how these are set up - it may well be geographically determined or part of load balancing.

Nonetheless, this diff modifies the resolve-ipv4-address test to check the resolved IP address against all (currently) known IP addresses for example.com.

(Also, Hi Mark! I have another PR for this library coming soon - I am working on adding OpenBSD support.)